### PR TITLE
Use UUID for writing the output file

### DIFF
--- a/src/graccarchive/graccarchive.py
+++ b/src/graccarchive/graccarchive.py
@@ -24,7 +24,7 @@ def move_without_overwrite(src, orig_dest):
     while True:
         dest_dir, dest_fname = os.path.split(orig_dest)
         parts = dest_fname.split(".")
-        parts = [parts[0], "%d" % str(uuid.uuid4())] + parts[1:]
+        parts = [parts[0], "%s" % str(uuid.uuid4())] + parts[1:]
         dest_fname = ".".join(parts)
         dest = os.path.join(dest_dir, dest_fname)
         try:

--- a/src/graccarchive/graccarchive.py
+++ b/src/graccarchive/graccarchive.py
@@ -14,18 +14,18 @@ import cStringIO
 import threading
 import signal
 import sys
+import uuid
 
 import pika
 import toml
 
 def move_without_overwrite(src, orig_dest):
-    counter = 0
+    # Use a UUID in order to uniquely write the file
     while True:
         dest_dir, dest_fname = os.path.split(orig_dest)
-        if counter:
-            parts = dest_fname.split(".")
-            parts = [parts[0], "%d" % counter] + parts[1:]
-            dest_fname = ".".join(parts)
+        parts = dest_fname.split(".")
+        parts = [parts[0], "%d" % str(uuid.uuid4())] + parts[1:]
+        dest_fname = ".".join(parts)
         dest = os.path.join(dest_dir, dest_fname)
         try:
             fd = os.open(dest, os.O_CREAT|os.O_EXCL)
@@ -33,7 +33,6 @@ def move_without_overwrite(src, orig_dest):
         except OSError as oe:
             if (oe.errno != errno.EEXIST):
                 raise
-        counter += 1
     try:
         shutil.move(src, dest)
     finally:

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -74,6 +74,8 @@ systemctl restart graccarchive@test.service
 sleep 2
 ls -lRh /var/lib/graccarchive/
 
+journalctl -u graccarchive@test.service --no-pager -n 1000
+
 # Ok, there should be file in /var/lib/graccarchive/output, unarchive it!
 graccunarchiver "amqp://guest:guest@localhost/" gracc.osg.raw /var/lib/graccarchive/output/*
 


### PR DESCRIPTION
Using an UUID rather than a counter is necessary because we want each output file to be unique, even if it's in the secondary directory for backups already.