### PR TITLE
Usage gzip files and zero out members

### DIFF
--- a/src/graccarchive/graccarchive.py
+++ b/src/graccarchive/graccarchive.py
@@ -14,6 +14,7 @@ import cStringIO
 import threading
 import signal
 import sys
+import gzip
 
 import pika
 import pika.exceptions

--- a/src/graccarchive/graccarchive.py
+++ b/src/graccarchive/graccarchive.py
@@ -76,7 +76,7 @@ class ArchiverAgent(object):
         # TODO: capture exit codes on all these call
         self._chan.queue_declare(queue=self._config["AMQP"]['queue'], durable=True, auto_delete=self._config['AMQP'].get('auto_delete', False))
         self._chan.queue_bind(self._config["AMQP"]['queue'], self._config["AMQP"]['exchange'])
-        self._chan.basic_recover()
+        self._chan.basic_recover(requeue=True)
 
 
     def startReceiving(self):

--- a/src/graccarchive/graccarchive.py
+++ b/src/graccarchive/graccarchive.py
@@ -76,6 +76,7 @@ class ArchiverAgent(object):
         # TODO: capture exit codes on all these call
         self._chan.queue_declare(queue=self._config["AMQP"]['queue'], durable=True, auto_delete=self._config['AMQP'].get('auto_delete', False))
         self._chan.queue_bind(self._config["AMQP"]['queue'], self._config["AMQP"]['exchange'])
+        self._chan.basic_recover()
 
 
     def startReceiving(self):


### PR DESCRIPTION
Use the gzip file obj so we can flush the results.

Also, zero out the `members` variable of the tarfile so that memory usage does not linearly increase over time.